### PR TITLE
fix: add css version so you don t have to use less

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The inconsolata typeface by Raph Levien. From http://www.google.com/fonts/specim
 
     npm install inconsolata
 
+If you are in the context of webpack you can import it using the following
+
+    import '~incosolata/index.css';
+
 ## License
 
   The SIL Open Font License 1.1 (OFL-1.1).

--- a/index.css
+++ b/index.css
@@ -1,0 +1,12 @@
+@font-face {
+  font-family: 'Inconsolata';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Inconsolata'), url('inconsolata.woff') format('woff');
+}
+@font-face {
+  font-family: 'Inconsolata';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Inconsolata Bold'), local('Inconsolata-Bold'), url('inconsolata-bold.woff') format('woff');
+}


### PR DESCRIPTION
Current behavior:

In the context of a project using webpack, this font package require a special configuration to support less extensions (so require a less loader and in my case I'm using sass so ...)

New behavior 

The user can include it as a normal css file.
